### PR TITLE
Docker multistage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 [![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/bzPrOe11)
+
 # CS3219 Project (PeerPrep) - AY2425S1
+
 ## Group: G14
 
-### Note: 
-- You can choose to develop individual microservices within separate folders within this repository **OR** use individual repositories (all public) for each microservice. 
-- In the latter scenario, you should enable sub-modules on this GitHub classroom repository to manage the development/deployment **AND** add your mentor to the individual repositories as a collaborator. 
-- The teaching team should be given access to the repositories as we may require viewing the history of the repository in case of any disputes or disagreements. 
+### Note:
+
+- You can choose to develop individual microservices within separate folders within this repository **OR** use
+  individual repositories (all public) for each microservice.
+- In the latter scenario, you should enable sub-modules on this GitHub classroom repository to manage the
+  development/deployment **AND** add your mentor to the individual repositories as a collaborator.
+- The teaching team should be given access to the repositories as we may require viewing the history of the repository
+  in case of any disputes or disagreements.
+
+Run `docker compose up --build`

--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,0 +1,51 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+args_bin = []
+bin = "tmp/main.exe"
+cmd = "go build -o ./tmp/main.exe ."
+delay = 1000
+exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+exclude_file = []
+exclude_regex = ["_test.go"]
+exclude_unchanged = false
+follow_symlink = false
+full_bin = ""
+include_dir = []
+include_ext = ["go", "tpl", "tmpl", "html"]
+include_file = []
+kill_delay = "0s"
+log = "build-errors.log"
+poll = true # NOTE: set to true to work inside docker
+poll_interval = 0
+post_cmd = []
+pre_cmd = []
+rerun = false
+rerun_delay = 500
+send_interrupt = false
+stop_on_error = false
+
+[color]
+app = ""
+build = "yellow"
+main = "magenta"
+runner = "green"
+watcher = "cyan"
+
+[log]
+main_only = false
+time = false
+
+[misc]
+clean_on_exit = false
+
+[proxy]
+app_port = 0
+enabled = false
+proxy_port = 0
+
+[screen]
+clear_on_rebuild = false
+keep_scroll = true

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,32 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,29 +1,95 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
 
-# Set destination for COPY
-WORKDIR /backend
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
-# Download Go modules
-# TODO: don't include the .env file in the COPY
-# TODO: multistage build
-COPY go.mod go.sum ./
-RUN go mod download
+################################################################################
+# Create a stage for building the application.
+ARG GO_VERSION=1.23
+FROM golang:${GO_VERSION} AS build
+WORKDIR /src
 
-# Copy the source code. Note the slash at the end, as explained in
-# https://docs.docker.com/reference/dockerfile/#copy
-COPY . .
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage bind mounts to go.sum and go.mod to avoid having to copy them into
+# the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -o /backend/app
+# This is the architecture you're building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH=amd64
 
-# Optional:
-# To bind to a TCP port, runtime parameters must be supplied to the docker command.
-# But we can document in the Dockerfile what ports
-# the application is going to listen on by default.
-# https://docs.docker.com/reference/dockerfile/#expose
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,target=. \
+    CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server .
+
+
+FROM build AS dev
+
+
+COPY --from=build /bin/server /bin/server
+
 EXPOSE 9090
 
 # Run
-CMD ["/backend/app"]
+CMD ["/bin/server"]
+
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the alpine image as the foundation for running the app.
+# By specifying the "latest" tag, it will also use whatever happens to be the
+# most recent version of that image when you build your Dockerfile. If
+# reproducability is important, consider using a versioned tag
+# (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
+FROM alpine:latest AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+    apk --update add \
+        ca-certificates \
+        tzdata \
+        && \
+        update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+# Expose the port that the application listens on.
+EXPOSE 9090
+
+
+ENV MONGODB_URI="mongodb+srv://nxtms3:np0aUdwlMkISiUia@questions.bh9su.mongodb.net/?retryWrites=true&w=majority&appName=questions"
+ENV PORT=":9090"
+ENV CORS_ORIGIN="http://host.docker.internal:3000"
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server" ]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -41,8 +41,11 @@ COPY --from=build /bin/server /bin/server
 
 EXPOSE 9090
 
-# Run
-CMD ["/bin/server"]
+RUN go install github.com/air-verse/air@latest
+#COPY go.mod go.sum ./
+#RUN #go mod download
+
+ENTRYPOINT ["air", "-c", ".air.toml"]
 
 
 ################################################################################
@@ -56,7 +59,7 @@ CMD ["/bin/server"]
 # most recent version of that image when you build your Dockerfile. If
 # reproducability is important, consider using a versioned tag
 # (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
-FROM alpine:latest AS final
+FROM alpine:latest AS prod
 
 # Install any runtime dependencies that are needed to run your application.
 # Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.

--- a/backend/database/initialise_database.go
+++ b/backend/database/initialise_database.go
@@ -12,11 +12,12 @@ import (
 )
 
 func InitialiseDB() (*mongo.Client, error) {
-	// Load environment variables
-	err := godotenv.Load(".env")
 
-	if err != nil {
-		log.Fatal("Error loading environment variables: " + err.Error())
+	if os.Getenv("ENV") == "" {
+		err := godotenv.Load(".env")
+		if err != nil {
+			log.Fatal("Error loading environment variables: " + err.Error())
+		}
 	}
 
 	mongoURI := os.Getenv("MONGODB_URI")

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,8 +2,6 @@ module peerprep
 
 go 1.23
 
-require github.com/joho/godotenv v1.5.1 // indirect  -allows to load environment variables from a .env file instead of hardcoding them in the code
-
 require (
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
@@ -46,6 +44,7 @@ require (
 
 require (
 	github.com/gin-contrib/cors v1.7.2
+	github.com/joho/godotenv v1.5.1
 	github.com/microcosm-cc/bluemonday v1.0.27
 )
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,49 +1,126 @@
+x-common-environment:
+  environment:
+    - ENV=${ENV:-dev}
+
 services:
-  peerprep:
-    build: peerprep
+  peerprep-dev:
+    #    profiles:
+    #      - [ dev ]
+    depends_on:
+      - user-service-dev
+      - backend-dev
+    build:
+      context: peerprep
+      target: dev
     env_file:
       - peerprep/.env
+    environment:
+      - ENV=${ENV:-dev}
+    volumes:
+      - ./peerprep:/frontend
     ports:
-      - "3000:3000"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
+      - "${PEERPREP_PORT:-3000}:3000"
+    #    extra_hosts:
+    #      - "host.docker.internal:host-gateway"
+    networks:
+      - backend
+      - user-service
+      ####### Dockerfile Node is distroless, no curl
+      #    healthcheck:
+      #      test: [ "CMD", "curl", "-f", "http://localhost:3000/" ]
+    restart: on-failure
     develop:
       watch:
         - action: sync
           path: peerprep
           target: /frontend
 
-  user-service:
-    build: user-service
-    volumes:
-      - /user-service/node_modules
+
+  user-service-dev:
+    #    profiles:
+    #      - [ dev ]
+    build:
+      context: user-service
+      target: dev
     env_file:
       - user-service/.env
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    environment:
+      - ENV=${ENV:-PROD}
+    volumes:
+      - ./user-service:/user-service
     ports:
-      - "3001:3001"
+      - "${USER_SERVICE_PORT:-3001}:3001"
+    networks:
+      - user-service
+    #    extra_hosts:
+    #      - "host.docker.internal:host-gateway"
+    #    healthcheck:
+    #      test: [ "CMD", "curl", "-f", "http://localhost:3001/" ]
+    restart: on-failure
     develop:
       watch:
-        - action: rebuild
+        - action: sync
           path: user-service
           target: /user-service
 
+  #  user-service-prod:
+  #    extends:
+  #      service: user-service-dev
+  #    profiles:
+  #      - [ prod ]
+  #    environment:
+  #      - ENV=prod
+  #    build:
+  #      target: final
 
-  backend:
-    build: backend
+  backend-dev:
+    #    profiles:
+    #      - [ dev ]
+    build:
+      context: backend
+      target: dev
     env_file:
       - backend/.env
+    environment:
+      - ENV=${ENV:-dev}
+
+    volumes:
+      - logs:/log
+      - ./backend:/src
     ports:
-      - "9090:9090"
+      - "${BACKEND_PORT:-9090}:9090"
+    networks:
+      - backend
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9090/health" ]
+    restart: on-failure
     develop:
       watch:
         - action: rebuild
           path: backend
           target: backend/app
 
+
+#    backend-prod:
+#      extends:
+#        service: backend-prod
+#      profiles:
+#        - [ prod ]
+#      environment:
+#        - ENV=prod
+#      build:
+#        target: final
+
 #  mongo:
 #    image: "mongo:latest"
 #    ports:
 #      - "27017:27017"
+
+networks:
+  backend:
+    driver: bridge
+  user-service:
+    driver: bridge
+
+volumes:
+  logs:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,10 +2,10 @@ x-common-environment:
   environment:
     - ENV=${ENV:-dev}
 
+# NOTE: Ports do not need to be exposed if not needed to expose outside the network
+
 services:
   peerprep-dev:
-    #    profiles:
-    #      - [ dev ]
     depends_on:
       - user-service-dev
       - backend-dev
@@ -20,8 +20,6 @@ services:
       - ./peerprep:/frontend
     ports:
       - "${PEERPREP_PORT:-3000}:3000"
-    #    extra_hosts:
-    #      - "host.docker.internal:host-gateway"
     networks:
       - backend
       - user-service
@@ -42,18 +40,20 @@ services:
     build:
       context: user-service
       target: dev
+    depends_on:
+      - mongo-dev
     env_file:
       - user-service/.env
     environment:
-      - ENV=${ENV:-PROD}
+      - ENV=${ENV:-DEV}
     volumes:
       - ./user-service:/user-service
     ports:
       - "${USER_SERVICE_PORT:-3001}:3001"
     networks:
       - user-service
-    #    extra_hosts:
-    #      - "host.docker.internal:host-gateway"
+      - user-mongo
+    ##### No curl on distroless node
     #    healthcheck:
     #      test: [ "CMD", "curl", "-f", "http://localhost:3001/" ]
     restart: on-failure
@@ -83,7 +83,6 @@ services:
       - backend/.env
     environment:
       - ENV=${ENV:-dev}
-
     volumes:
       - logs:/log
       - ./backend:/src
@@ -101,26 +100,36 @@ services:
           target: backend/app
 
 
-#    backend-prod:
-#      extends:
-#        service: backend-prod
-#      profiles:
-#        - [ prod ]
-#      environment:
-#        - ENV=prod
-#      build:
-#        target: final
+  #    backend-prod:
+  #      extends:
+  #        service: backend-prod
+  #      profiles:
+  #        - [ prod ]
+  #      environment:
+  #        - ENV=prod
+  #      build:
+  #        target: final
 
-#  mongo:
-#    image: "mongo:latest"
-#    ports:
-#      - "27017:27017"
+  mongo-dev:
+    image: "mongo:latest"
+    restart: on-failure
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - "27017:27017"
+      - "${usermongoport:-27017}:27017"
+    networks:
+      - user-mongo
+
 
 networks:
   backend:
     driver: bridge
   user-service:
     driver: bridge
+  user-mongo:
+    driver: bridge
 
 volumes:
   logs:
+  mongo-data:

--- a/peerprep/.dockerignore
+++ b/peerprep/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/peerprep/Dockerfile
+++ b/peerprep/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:lts-alpine3.20
+####### See also https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+
+
+FROM node:lts-alpine3.20 AS base
 
 WORKDIR /frontend
 # TODO: don't include the .env file in the COPY
@@ -7,4 +10,10 @@ COPY package*.json ./
 RUN npm install
 COPY . .
 EXPOSE 3000
+
+
+FROM base AS dev
 CMD ["npm", "run", "dev"]
+
+FROM base AS prod
+CMD ["npm", "run", "build", "&&", "npm", "run", "start"]

--- a/peerprep/next.config.js
+++ b/peerprep/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
-
-module.exports = nextConfig
+module.exports = {
+  output: "standalone",
+};

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,20 @@
+# https://docs.docker.com/reference/compose-file/merge/#replace-value
+# run using `docker compose up -f compose.yaml -f production.yml`
+
+x-common-environment:
+  environment:
+    - ENV=${ENV:-PROD}
+
+services:
+  peerprep-dev:
+    build:
+      target: prod
+
+  user-service-dev:
+    depends_on: !reset [ ]
+    build:
+      target: prod
+
+  backend-dev:
+    build:
+      target: prod

--- a/user-service/.dockerignore
+++ b/user-service/.dockerignore
@@ -1,2 +1,34 @@
-/node_modules
-package-lock.json
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,11 +1,46 @@
-FROM node:22
+#FROM node:22-alpine as base
+#
+#WORKDIR /user-service
+#COPY package*.json ./
+#
+#RUN npm ci
+#RUN npm rebuild bcrypt --build-from-source
+#COPY . .
+#
+#
+#ENV DB_CLOUD_URI="mongodb+srv://modemhappy:dvVbAqwq5lEOr6WN@cluster0.1oehu.mongodb.net/peerprep?retryWrites=true&w=majority&appName=Cluster0"
+#ENV DB_LOCAL_URI="mongodb://127.0.0.1:27017/peerprepUserServiceDB"
+#ENV PORT=3001
+#ENV ENV=PROD
+#ENV JWT_SECRET=you-can-replace-this-with-your-own-secret
+#
+#
+#EXPOSE 3001
+#CMD ["npm", "run", "start"]
 
-WORKDIR /user-service
-# TODO: don't include the .env file in the COPY
-# TODO: multistage build
-COPY package*.json ./
-RUN npm install
-RUN npm rebuild bcrypt --build-from-source
-COPY . .
+
+ARG NODE_VERSION=22
+
+FROM node:${NODE_VERSION}-alpine AS base
+WORKDIR /usr/src/app
 EXPOSE 3001
-CMD ["npm", "run", "start"]
+
+FROM base AS dev
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci --include=dev \
+RUN npm rebuild bcrypt --build-from-source
+USER node
+COPY . .
+CMD npm run dev
+
+FROM base AS prod
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=package-lock.json,target=package-lock.json \
+    --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev \
+RUN npm rebuild bcrypt --build-from-source
+USER node
+COPY . .
+CMD npm run start


### PR DESCRIPTION
Note that inter-network communication is via *service-names* if using Docker Compose e.g. `http://user-service:3001`, so no need to use `http://localhost` or `http://host.docker.internal:3000`. Outside compose, I think it's via the id/hash [doc](https://docs.docker.com/engine/network/#ip-address-and-hostname)

So run `docker compose up --build` to rebuild containers.

A number of options useful including `-V` to refresh volumes and `--force-recreate`, if `--build` isn't sufficient
[docs](https://docs.docker.com/reference/cli/docker/compose/up/)

Changes:
- Use multistage builds in Dockerfile
- Add live reload for Go while in container using air

TODO:
- make `npm build` not fail for frontend to fully utilise multistage builds
- inject secrets rather than `.env` files in `compose.yml` and in the code
- ~~compose profiles for dev and prod envs~~ profiles seem a worse way than merging compose files