### PR TITLE
Add room persistence and fix bugs

### DIFF
--- a/collab/verify/persistMappings.go
+++ b/collab/verify/persistMappings.go
@@ -1,0 +1,34 @@
+package verify
+
+import (
+	"context"
+	"log"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+// same as room mappings, but separated for type safety
+type PersistMappings struct {
+	Conn *redis.Client
+}
+
+func InitialisePersistMappings(addr string, db_num int) *PersistMappings {
+	conn := redis.NewClient(&redis.Options{
+		Addr: addr,
+		DB:   db_num,
+	})
+
+	return &PersistMappings{
+		Conn: conn,
+	}
+}
+
+func VerifyPersist(persistMappings *PersistMappings, roomID string, userID string) bool {
+	data, err := persistMappings.Conn.HGetAll(context.Background(), userID).Result()
+	if err != nil {
+		log.Printf("Error retrieving data for userID %s: %v", userID, err)
+		return false
+	}
+
+	return data["roomId"] == roomID
+}

--- a/matching-service-api/mappings/client_mappings.go
+++ b/matching-service-api/mappings/client_mappings.go
@@ -1,0 +1,18 @@
+package mappings
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+)
+
+func GenerateMatchingHash() (string, error) {
+	bytes := make([]byte, 16)
+
+	if _, err := io.ReadFull(rand.Reader, bytes); err != nil {
+		return "", errors.New("Failed to generate random matching hash" + err.Error())
+	}
+
+	return hex.EncodeToString(bytes), nil
+}

--- a/matching-service-api/models/request.go
+++ b/matching-service-api/models/request.go
@@ -1,6 +1,8 @@
 package models
 
 type Request struct {
+	MatchHash string
+
 	UserId string `json:"userId"` 
 
 	TopicTags []string `json:"topicTags"`

--- a/matching-service/main.go
+++ b/matching-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 
 	"matching-service/consumer"
 	models "matching-service/models"
@@ -99,9 +100,30 @@ func main() {
 	if REDIS_URI == "" {
 		REDIS_URI = "localhost://9190"
 	}
+
+	REDIS_CLIENT_MAPPING := 0
+	REDIS_ROOM_MAPPING   := 1
+
+	if os.Getenv("REDIS_CLIENT_MAPPING") != "" {
+		num, err := strconv.Atoi(os.Getenv("REDIS_CLIENT_MAPPING"))
+		if err != nil {
+			log.Fatal("DB no of client map is badly formatted" + err.Error())
+		} else {
+			REDIS_CLIENT_MAPPING = num
+		}
+	}
+
+	if os.Getenv("REDIS_ROOM_MAPPING") != "" {
+		num, err := strconv.Atoi(os.Getenv("REDIS_ROOM_MAPPING"))
+		if err != nil {
+			log.Fatal("DB no of room map is badly formatted" + err.Error())
+		} else {
+			REDIS_ROOM_MAPPING = num
+		}
+	}
 	
-	clientMappings := storage.InitialiseClientMappings(REDIS_URI, 0)
-	roomMappings := storage.InitialiseRoomMappings(REDIS_URI, 1)
+	clientMappings := storage.InitialiseClientMappings(REDIS_URI, REDIS_CLIENT_MAPPING)
+	roomMappings := storage.InitialiseRoomMappings(REDIS_URI, REDIS_ROOM_MAPPING)
 
 
 	logger.Log.Info("Beginning consumption from message queue")

--- a/matching-service/models/matching_request.go
+++ b/matching-service/models/matching_request.go
@@ -1,6 +1,7 @@
 package models
 
 type IncomingRequests struct {
+	MatchHash   string	 `json:"matchHash"`
 	UserId      string   `json:"userId"`
 	TopicTags   []string `json:"topicTags"`
 	Difficulty  string   `json:"difficulty"`

--- a/matching-service/models/room.go
+++ b/matching-service/models/room.go
@@ -1,7 +1,11 @@
 package models
 
 type Room struct {
+	// stores what key to ship the resulting blob to
+	MatchHash1 string `json:"matchHash1"`
+	MatchHash2 string `json:"matchHash2"`
 	
+	// user information
 	RoomId     string	`json:"roomId"`
 	User1      string	`json:"user1"`
 	User2      string	`json:"user2"`

--- a/matching-service/storage/room_mappings.go
+++ b/matching-service/storage/room_mappings.go
@@ -40,8 +40,10 @@ func (db *RoomMappings) SendToStorageBlob(room *models.Room) error {
 		return fmt.Errorf("error marshling topics: %s", err.Error())
 	}
 
+	// this is where the value is being set
 	user1_info := map[string]interface{}{
 		"roomId":      room.RoomId,
+		"thisUser":    room.User1,
 		"otherUser":   room.User2,
 		"requestTime": room.RequestTime,
 
@@ -56,6 +58,7 @@ func (db *RoomMappings) SendToStorageBlob(room *models.Room) error {
 
 	user2_info := map[string]interface{}{
 		"roomId":      room.RoomId,
+		"thisUser":    room.User2,
 		"otherUser":   room.User1,
 		"requestTime": room.RequestTime,
 
@@ -68,11 +71,12 @@ func (db *RoomMappings) SendToStorageBlob(room *models.Room) error {
 		"id":         room.QuestionId,
 	}
 
-	if err1 := db.Conn.HSet(ctx, room.User1, user1_info).Err(); err1 != nil {
+	// TODO: Modify this - this is where the key-value is being set
+	if err1 := db.Conn.HSet(ctx, room.MatchHash1, user1_info).Err(); err1 != nil {
 		return fmt.Errorf("error setting user1's room to storage: %s", err1.Error())
 	}
 
-	if err2 := db.Conn.HSet(ctx, room.User2, user2_info).Err(); err2 != nil {
+	if err2 := db.Conn.HSet(ctx, room.MatchHash2, user2_info).Err(); err2 != nil {
 		return fmt.Errorf("error setting user2's room to storage: %s", err2.Error())
 	}
 
@@ -86,11 +90,11 @@ func (db *RoomMappings) SendToStorageBlob(room *models.Room) error {
 
 	diff := int(time.Until(expiryTime).Seconds())
 
-	if err1 := db.Conn.Expire(ctx, room.User1, time.Duration(diff)*time.Second).Err(); err1 != nil {
+	if err1 := db.Conn.Expire(ctx, room.MatchHash1, time.Duration(diff)*time.Second).Err(); err1 != nil {
 		return fmt.Errorf("error setting expiry time on room data: %s", err1.Error())
 	}
 
-	if err2 := db.Conn.Expire(ctx, room.User2, time.Duration(diff)*time.Second).Err(); err2 != nil {
+	if err2 := db.Conn.Expire(ctx, room.MatchHash2, time.Duration(diff)*time.Second).Err(); err2 != nil {
 		return fmt.Errorf("error setting expiry time on room data: %s", err2.Error())
 	}
 

--- a/peerprep/api/structs.ts
+++ b/peerprep/api/structs.ts
@@ -55,6 +55,10 @@ export interface MatchRequest {
   requestTime: string;
 }
 
+export interface MatchReqInitRes {
+  match_code: string;
+}
+
 export interface MatchData {
   roomId: string;
   user1: string;

--- a/peerprep/app/api/internal/matching/helper.ts
+++ b/peerprep/app/api/internal/matching/helper.ts
@@ -3,15 +3,16 @@ import {
   MatchRequest,
   MatchResponse,
   StatusBody,
+  MatchReqInitRes
 } from "@/api/structs";
 
 // helper to be called from client to check storage blob
 export async function checkMatchStatus(
-  userId: string
+  matchHash: string
 ): Promise<MatchResponse | StatusBody> {
-  console.debug("In matching helper, checking storage blob:", userId);
+  console.debug("In matching helper, checking storage blob:", matchHash);
   const res = await fetch(
-    `${process.env.NEXT_PUBLIC_NGINX}/api/internal/matching?uid=${userId}`,
+    `${process.env.NEXT_PUBLIC_NGINX}/api/internal/matching?matchHash=${matchHash}`,
     {
       method: "GET",
     }
@@ -33,7 +34,7 @@ export async function checkMatchStatus(
 
 export async function findMatch(
   matchRequest: MatchRequest
-): Promise<StatusBody> {
+): Promise<StatusBody|MatchReqInitRes> {
   console.debug(
     "In matching helper, posting match request",
     JSON.stringify(matchRequest)
@@ -49,8 +50,8 @@ export async function findMatch(
     return {
       error: await res.text(),
       status: res.status,
-    };
+    } as StatusBody;
   }
   const json = await res.json();
-  return json as StatusBody;
+  return json as MatchReqInitRes;
 }

--- a/peerprep/app/api/internal/matching/route.ts
+++ b/peerprep/app/api/internal/matching/route.ts
@@ -4,15 +4,15 @@ import { NextRequest, NextResponse } from "next/server";
 
 // all get request interpreted as getting from storage blob
 export async function GET(request: NextRequest) {
-  const uid = request.nextUrl.searchParams.get("uid"); // Assuming you're passing the userId as a query parameter
-  console.log("in route,", uid);
-  if (!uid) {
-    return NextResponse.json({ error: "User ID is required" }, { status: 400 });
+  const matchHash = request.nextUrl.searchParams.get("matchHash"); // Assuming you're passing the userId as a query parameter
+  console.log("in route,", matchHash);
+  if (!matchHash) {
+    return NextResponse.json({ error: "MatchHash is required" }, { status: 400 });
   }
 
   try {
     const response = await fetch(
-      `${process.env.NEXT_PUBLIC_STORAGE_BLOB}/request/${uid}`,
+      `${process.env.NEXT_PUBLIC_STORAGE_BLOB}/request/${matchHash}`,
       {
         method: "GET",
         headers: generateAuthHeaders(),
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     );
     if (response.ok) {
       return NextResponse.json(
-        { status: response.status },
+        { match_code: (await response.json()).match_code },
         { status: response.status }
       );
     }

--- a/peerprep/app/questions/[question]/[roomID]/page.tsx
+++ b/peerprep/app/questions/[question]/[roomID]/page.tsx
@@ -6,13 +6,16 @@ import React from "react";
 import QuestionBlock from "./question";
 
 type Props = {
+  searchParams: {
+    match?: string
+  },
   params: {
     question: string;
     roomID: string;
   };
 };
 
-async function Question({ params }: Props) {
+async function Question({ params, searchParams }: Props) {
   const question = await fetchQuestion(params.question);
 
   return (
@@ -24,6 +27,7 @@ async function Question({ params }: Props) {
           question={question as QnType}
           roomID={params.roomID}
           authToken={getSessionToken()}
+          matchHash={searchParams.match}
         />
       )}
     </div>

--- a/peerprep/app/questions/[question]/[roomID]/question.tsx
+++ b/peerprep/app/questions/[question]/[roomID]/question.tsx
@@ -7,7 +7,7 @@ import styles from "@/style/question.module.css";
 import { useRouter } from "next/navigation";
 import { deleteQuestion } from "@/app/api/internal/questions/helper";
 import CollabEditor from "@/components/questionpage/CollabEditor";
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 
 interface Props {
   question: Question;

--- a/peerprep/app/questions/[question]/[roomID]/question.tsx
+++ b/peerprep/app/questions/[question]/[roomID]/question.tsx
@@ -13,6 +13,7 @@ interface Props {
   question: Question;
   roomID?: String;
   authToken?: String;
+  matchHash?: String;
 }
 
 interface DifficultyChipProps {
@@ -29,7 +30,7 @@ function DifficultyChip({ diff }: DifficultyChipProps) {
   );
 }
 
-function QuestionBlock({ question, roomID, authToken }: Props) {
+function QuestionBlock({ question, roomID, authToken, matchHash }: Props) {
   const router = useRouter();
 
   const handleDelete = async () => {
@@ -95,6 +96,7 @@ function QuestionBlock({ question, roomID, authToken }: Props) {
           question={question}
           roomID={roomID}
           authToken={authToken}
+          matchHash={matchHash}
         />
       </div>
     </>

--- a/peerprep/app/questions/[question]/question.tsx
+++ b/peerprep/app/questions/[question]/question.tsx
@@ -7,7 +7,7 @@ import styles from "@/style/question.module.css";
 import { useRouter } from "next/navigation";
 import { deleteQuestion } from "@/app/api/internal/questions/helper";
 import CollabEditor from "@/components/questionpage/CollabEditor";
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 
 interface Props {
   question: Question;

--- a/peerprep/components/questionpage/CollabEditor.tsx
+++ b/peerprep/components/questionpage/CollabEditor.tsx
@@ -78,7 +78,7 @@ export default function CollabEditor({ question, roomID, authToken, matchHash }:
 
     console.log("Yep");
 
-    const newSocket = new WebSocket(`ws://localhost:4000/ws?roomID=${roomID}`);
+    const newSocket = new WebSocket(`/api/proxy?roomID=${roomID}`);
 
     newSocket.onopen = () => {
       console.log("WebSocket connection established");

--- a/peerprep/components/questionpage/CollabEditor.tsx
+++ b/peerprep/components/questionpage/CollabEditor.tsx
@@ -48,9 +48,10 @@ interface Props {
   question: Question;
   roomID?: String;
   authToken?: String;
+  matchHash?: String;
 }
 
-export default function CollabEditor({ question, roomID, authToken }: Props) {
+export default function CollabEditor({ question, roomID, authToken, matchHash }: Props) {
   const [theme, setTheme] = useState("terminal");
   const [fontSize, setFontSize] = useState(18);
   const [language, setLanguage] = useState("python");
@@ -86,6 +87,7 @@ export default function CollabEditor({ question, roomID, authToken }: Props) {
       const authMessage = {
         type: "auth",
         token: authToken,
+        matchHash: matchHash // omitted if undefined
       };
       newSocket.send(JSON.stringify(authMessage));
     };

--- a/peerprep/components/shared/PeerprepButton.tsx
+++ b/peerprep/components/shared/PeerprepButton.tsx
@@ -6,15 +6,17 @@ type PeerprepButtonProps = {
   onClick: () => void;
   children: React.ReactNode;
   className?: string;
+  disabled?: boolean
 };
 
 const PeerprepButton: React.FC<PeerprepButtonProps> = ({
   onClick,
   children,
   className,
+  disabled
 }) => {
   return (
-    <button onClick={onClick} className={`${styles.button} ${className}`}>
+    <button onClick={onClick} className={`${styles.button} ${className}`} disabled={disabled}>
       {children}
     </button>
   );

--- a/peerprep/next.config.js
+++ b/peerprep/next.config.js
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {}
 
-module.exports = nextConfig
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/proxy', // client connects to api/proxy
+        // by default we expect NEXT_PUBLIC_COLLAB to be http://collab:4000.
+        // double check this before using this.
+        destination: `${process.env.NEXT_PUBLIC_COLLAB}/ws`,
+      }
+    ]
+  }
+}

--- a/peerprep/package-lock.json
+++ b/peerprep/package-lock.json
@@ -3250,6 +3250,7 @@
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.16.0.tgz",
       "integrity": "sha512-cXhX2owp8rPxafCr0ywqy2CGI/4ceLNgWkWBEvUz64KTbtg3oRL2ZRqq/zW0pzt4YtDjkHLbwcp/lozpKzAQjg==",
+      "license": "MIT",
       "dependencies": {
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.1.7",

--- a/storage-blob-api/main.go
+++ b/storage-blob-api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
@@ -52,8 +53,19 @@ func main() {
 	if REDIS_URI == "" {
 		REDIS_URI = "localhost://9190"
 	}
+	
+	REDIS_ROOM_MAPPING   := 1
 
-	roomMappings := storage.InitialiseRoomMappings(REDIS_URI, 1)	
+	if os.Getenv("REDIS_ROOM_MAPPING") != "" {
+		num, err := strconv.Atoi(os.Getenv("REDIS_ROOM_MAPPING"))
+		if err != nil {
+			log.Fatal("DB no of room map is badly formatted" + err.Error())
+		} else {
+			REDIS_ROOM_MAPPING = num
+		}
+	}
+
+	roomMappings := storage.InitialiseRoomMappings(REDIS_URI, REDIS_ROOM_MAPPING)	
 
 	router := gin.Default()
 	transport.SetCors(router, ORIGIN)

--- a/storage-blob-api/transport/endpoint.go
+++ b/storage-blob-api/transport/endpoint.go
@@ -10,7 +10,7 @@ import (
 )
 
 func SetAllEndpoints(router *gin.Engine, db *storage.RoomMappings, logger *models.Logger) {
-	router.GET("/request/:userId", HandleRequest(db, logger))
+	router.GET("/request/:matchHash", HandleRequest(db, logger))
 }
 
 func SetCors(router *gin.Engine, origin string) {


### PR DESCRIPTION
## Major changes

- Matches now match by a random hash generated from the matching-service-api. The hash is propagated to both the client and the matching-service - the client uses this hash to query the storage blob. Resultingly, the match result now also stores the user ID of the person who initiated the match under the match hash.
- The collab service now adds persistence to the room via a 3rd Redis instance - this room currently does not expire, at all, allowing for infinite reconnects. This should be a good to change.
- Matches are now immediately destroyed the moment the collab service takes over the room, as the room is "moved" to the persistent service.
- The client no longer has a pop-up to tell them of a successful match. Instead, the client is immediately redirected to the collab service. To implement this, a disable property is added to the `PeerprepButton` element, to prevent users from clicking the button during redirection.

## Known Bugs

- Closing the room does not destroy the persistent room right now.
- Changing to a random hash exposed an existing bug where a user could have matched to a cancelled user and be redirected to a collab service. It is more serious on this merge, as the user can match with themselves due to the matching hash being unique between subsequent calls. A viable fix would be to have the cancellation call propagate to the matching-service-api, as cancellation on the frontend does not do anything right now.